### PR TITLE
updating library version to fix KB-8183: "Load more" should not be sh…

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sunbird-cb/design-system": "0.0.1",
     "@sunbird-cb/micro-surveys": "2.0.20-ang-13-16",
     "@sunbird-cb/resolver": "1.0.0-ang-13-16",
-    "@sunbird-cb/taxonomy-editor": "0.0.1-ang-13-16",
+    "@sunbird-cb/taxonomy-editor": "0.0.2-ang-13-16",
     "@sunbird-cb/utils": "1.0.21-ang-13-16",
     "@sunbird-cb/rain-dashboards": "0.0.36-ang-13-16",
     "@types/file-saver": "^2.0.1",


### PR DESCRIPTION
…own when all the designations are loaded in ODCS