### PR TITLE
fix draft visibility and create community access for moderator roles

### DIFF
--- a/project/ws/app/src/lib/routes/home/routes/community/components/community-dashboard/community-dashboard.component.html
+++ b/project/ws/app/src/lib/routes/home/routes/community/components/community-dashboard/community-dashboard.component.html
@@ -2,7 +2,7 @@
   <div class="header">
     <h1>Communities</h1>
 
-    <button mat-button class="createBtn" (click)="onCreateCommunity()" *ngIf="isCommunityCreateRole">Create New
+    <button mat-button class="createBtn" (click)="onCreateCommunity()" *ngIf="filteredTabs.length>1">Create New
       Community</button>
   </div>
 
@@ -21,17 +21,10 @@
   </mat-tab-group> -->
 
   <mat-tab-group [(selectedIndex)]="selectedTabIndex" (selectedTabChange)="onTabChange($event)">
-    <ng-container *ngIf="isCommunityModeratorOnly">
-      <mat-tab>
-        <ng-template mat-tab-label>
-          Community
-        </ng-template>
-        <ng-container *ngTemplateOutlet="tabContent"></ng-container>
-      </mat-tab>
-    </ng-container>
 
-    <ng-container *ngIf="!isCommunityModeratorOnly">
-      <mat-tab *ngFor="let tab of tabs">
+
+    <ng-container *ngIf="!(filteredTabs?.length === 1 && (filteredTabs[0] | keyvalue).length === 0)">
+      <mat-tab *ngFor="let tab of filteredTabs">
         <ng-template mat-tab-label>
           {{tab?.label}}
         </ng-template>
@@ -142,7 +135,7 @@
             </button>
 
             <button mat-menu-item (click)="onActionClick('manage', row)"
-              *ngIf="isCommunityModeratorRole && currentStatus==='active'">
+              *ngIf="filteredTabs.length>1&& currentStatus==='active'">
               <mat-icon>settings</mat-icon>
               <span>Manage</span>
             </button>

--- a/project/ws/app/src/lib/routes/home/routes/community/components/community-dashboard/community-dashboard.component.ts
+++ b/project/ws/app/src/lib/routes/home/routes/community/components/community-dashboard/community-dashboard.component.ts
@@ -45,10 +45,6 @@ export class CommunityDashboardComponent implements OnInit {
   currentStatus = 'active'
   // private destroySubject$ = new Subject()
   masterData: any = {}
-  isCommunityModeratorRole = false
-  isCommunityCreateRole = false
-  isCommunityModeratorOnly = false
-
   tabs = [
     {
       label: 'Community',
@@ -66,6 +62,7 @@ export class CommunityDashboardComponent implements OnInit {
     //   icon: 'archive'
     // }
   ]
+  filteredTabs = [{}];
   selectedTabIndex = 0
 
   @ViewChild(MatPaginator) paginator!: MatPaginator
@@ -93,21 +90,10 @@ export class CommunityDashboardComponent implements OnInit {
   getOrgRolesList(): void {
     if (_.get(this.activatedRoute, 'snapshot.data.configService.unMappedUser')) {
       this.userProfile = _.get(this.activatedRoute, 'snapshot.data.configService.unMappedUser')
-      const userRole = this.userProfile.roles
-      const targetRoles = ['COMMUNITY_MODERATOR', 'MDO_LEADER']
-      const itemPresent = targetRoles.some((role: any) => userRole.includes(role))
-      if (itemPresent) {
-        this.isCommunityModeratorRole = true
-      }
-      const mdoLeaderPresent = userRole.some((role: any) => role.includes('MDO_LEADER'))
-      if (mdoLeaderPresent) {
-        this.isCommunityCreateRole = true
-      }
-      const isCommunityModeratorOnlyPresent = userRole?.some((role: any) => role?.includes('COMMUNITY_MODERATOR'))
-      if (isCommunityModeratorOnlyPresent) {
-        this.isCommunityModeratorOnly = true
-      }
-
+      const rolesSet = new Set(this.userProfile.roles)
+      this.filteredTabs = rolesSet.has('COMMUNITY_MODERATOR') &&!rolesSet.has('MDO_LEADER')
+        ? this.tabs.filter(t => t.label === 'Community')
+        : this.tabs;
     }
 
   }


### PR DESCRIPTION
Previously, users with the roles COMMUNITY_MODERATOR and MDO_LEADER were unable to view draft communities or access the Create Community button. This update ensures correct visibility and access based on role permissions.