### PR TITLE
fixed prefill designation dropdown on edit user

### DIFF
--- a/project/ws/app/src/lib/routes/home/components/user-cards/user-card.component.html
+++ b/project/ws/app/src/lib/routes/home/components/user-cards/user-card.component.html
@@ -138,6 +138,7 @@
                     <mat-option [value]="designation?.name" *ngFor="let designation of filterDesignationsMeta">
                       {{designation?.name}}
                     </mat-option>
+                    <mat-option *ngIf="updateUserDataForm.get('designation')?.value" [value]="updateUserDataForm.get('designation')?.value" disabled >{{updateUserDataForm.get('designation')?.value}}</mat-option>
                     <!-- No results message -->
                     <mat-option *ngIf="(filterDesignationsMeta )?.length === 0" disabled>
                       No matches found


### PR DESCRIPTION
This PR fixes an issue in the MDO Portal  Edit User flow where the Designation drop-down value was not pre-selected when editing an existing user who already has a designation assigned.

The update ensures the designation value is correctly populated in the drop-down during edit.