### PR TITLE
Fixed course not being added from paginated search results in Trainin…

### DIFF
--- a/project/ws/app/src/lib/routes/training-plan/routes/create-content/create-content.component.ts
+++ b/project/ws/app/src/lib/routes/training-plan/routes/create-content/create-content.component.ts
@@ -101,11 +101,11 @@ export class CreateContentComponent implements OnInit, OnChanges {
             }
           })
         }
-        this.contentData = this.tpdsSvc.trainingPlanContentData.data.content
+        this.contentData = [...this.tpdsSvc.trainingPlanContentData.data.content]
         this.count = this.tpdsSvc.trainingPlanContentData.data.count
         this.handleSelectedChips(true)
       } else {
-        this.contentData = this.tpdsSvc.trainingPlanContentData.data.content
+        this.contentData = [...this.tpdsSvc.trainingPlanContentData.data.content]
         this.count = this.tpdsSvc.trainingPlanContentData.data.count
       }
     }
@@ -114,7 +114,7 @@ export class CreateContentComponent implements OnInit, OnChanges {
   handleSelectedChips(event: any) {
     this.selectContentCount = 0
     if (event) {
-      this.selectedContentChips = this.tpdsSvc.trainingPlanContentData.data.content
+      this.selectedContentChips = [...this.tpdsSvc.trainingPlanContentData.data.content]
       if (this.selectedContentChips) {
         this.selectedContentChips.forEach(sitem => {
           if (sitem && sitem.selected) {


### PR DESCRIPTION
Fixed an intermittent issue in MDO Portal where courses selected from
page 2 or 3 of the Add Content search were not added to the Training Plan.

The issue was caused by improper state update while merging paginated
search results. This has been resolved by using the spread operator to
create a new reference when updating the selected content list, ensuring
Angular change detection and state consistency across pages.
